### PR TITLE
acceptance: Make test fields dynamic (#121)

### DIFF
--- a/build/Makefile.test
+++ b/build/Makefile.test
@@ -27,7 +27,7 @@ tests: unit
 ## Runs the Terraform acceptance tests. Use TEST_NAME, TESTARGS and TEST_COUNT to control execution
 testacc:
 	@ echo "-> Running terraform acceptance tests..."
-	@ TF_ACC=1 go test $(TEST_ACC) -v -count $(TEST_COUNT) -parallel 20 $(TESTARGS) -timeout 120m -run $(TEST_NAME)
+	@ TF_ACC=1 go test $(TEST_ACC) -v -count $(TEST_COUNT) -parallel 20 $(TESTARGS) -timeout 120m -run $(TEST_NAME) -tags=acceptance
 
 .PHONY: sweep
 ## Destroys any dangling infrastructure created by the acceptance tests (terraform_acc_ prefix).

--- a/ec/acc/acc_prereq.go
+++ b/ec/acc/acc_prereq.go
@@ -15,6 +15,8 @@
 // specific language governing permissions and limitations
 // under the License.
 
+// +build acceptance
+
 package acc
 
 import (

--- a/ec/acc/datasource_stack_test.go
+++ b/ec/acc/datasource_stack_test.go
@@ -15,6 +15,8 @@
 // specific language governing permissions and limitations
 // under the License.
 
+// +build acceptance
+
 package acc
 
 import (
@@ -28,7 +30,7 @@ import (
 func TestAccDatasourceStack_latest(t *testing.T) {
 	datasourceName := "data.ec_stack.latest"
 	depCfg := "testdata/datasource_stack_latest.tf"
-	cfg := testAccStackDataSource(t, depCfg, region)
+	cfg := fixtureAccStackDataSource(t, depCfg, getRegion())
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:          func() { testAccPreCheck(t) },
@@ -40,7 +42,7 @@ func TestAccDatasourceStack_latest(t *testing.T) {
 				Check: checkDataSourceStack(datasourceName,
 					resource.TestCheckResourceAttr(datasourceName, "version_regex", "latest"),
 					resource.TestCheckResourceAttr(datasourceName, "lock", "true"),
-					resource.TestCheckResourceAttr(datasourceName, "region", region),
+					resource.TestCheckResourceAttr(datasourceName, "region", getRegion()),
 				),
 			},
 		},
@@ -50,7 +52,7 @@ func TestAccDatasourceStack_latest(t *testing.T) {
 func TestAccDatasourceStack_regex(t *testing.T) {
 	datasourceName := "data.ec_stack.regex"
 	depCfg := "testdata/datasource_stack_regex.tf"
-	cfg := testAccStackDataSource(t, depCfg, region)
+	cfg := fixtureAccStackDataSource(t, depCfg, getRegion())
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:          func() { testAccPreCheck(t) },
@@ -61,14 +63,14 @@ func TestAccDatasourceStack_regex(t *testing.T) {
 				PreventDiskCleanup: true,
 				Check: checkDataSourceStack(datasourceName,
 					resource.TestCheckResourceAttr(datasourceName, "version_regex", "7.0.?"),
-					resource.TestCheckResourceAttr(datasourceName, "region", region),
+					resource.TestCheckResourceAttr(datasourceName, "region", getRegion()),
 				),
 			},
 		},
 	})
 }
 
-func testAccStackDataSource(t *testing.T, fileName, region string) string {
+func fixtureAccStackDataSource(t *testing.T, fileName, region string) string {
 	b, err := ioutil.ReadFile(fileName)
 	if err != nil {
 		t.Fatal(err)

--- a/ec/acc/deployment_basic_defaults_test.go
+++ b/ec/acc/deployment_basic_defaults_test.go
@@ -15,9 +15,13 @@
 // specific language governing permissions and limitations
 // under the License.
 
+// +build acceptance
+
 package acc
 
 import (
+	"fmt"
+	"io/ioutil"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
@@ -36,10 +40,10 @@ func TestAccDeployment_basic_defaults(t *testing.T) {
 	secondCfg := "testdata/deployment_basic_defaults_2.tf"
 	thirdCfg := "testdata/deployment_basic_defaults_3.tf"
 	fourthCfg := "testdata/deployment_basic_defaults_4.tf"
-	cfg := testAccDeploymentResourceBasic(t, startCfg, randomName, region, deploymentVersion)
-	secondConfigCfg := testAccDeploymentResourceBasic(t, secondCfg, randomName, region, deploymentVersion)
-	thirdConfigCfg := testAccDeploymentResourceBasic(t, thirdCfg, randomName, region, deploymentVersion)
-	hotWarmCfg := testAccDeploymentResourceBasic(t, fourthCfg, randomName, region, deploymentVersion)
+	cfg := fixtureAccDeploymentResourceBasicDefaults(t, startCfg, randomName, getRegion(), defaultTemplate)
+	secondConfigCfg := fixtureAccDeploymentResourceBasicDefaults(t, secondCfg, randomName, getRegion(), defaultTemplate)
+	thirdConfigCfg := fixtureAccDeploymentResourceBasicDefaults(t, thirdCfg, randomName, getRegion(), defaultTemplate)
+	hotWarmCfg := fixtureAccDeploymentResourceBasicDefaults(t, fourthCfg, randomName, getRegion(), hotWarmTemplate)
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:          func() { testAccPreCheck(t) },
@@ -163,4 +167,16 @@ func TestAccDeployment_basic_defaults(t *testing.T) {
 			},
 		},
 	})
+}
+
+func fixtureAccDeploymentResourceBasicDefaults(t *testing.T, fileName, name, region, depTpl string) string {
+	deploymentTpl := setDefaultTemplate(region, depTpl)
+
+	b, err := ioutil.ReadFile(fileName)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return fmt.Sprintf(string(b),
+		region, name, region, deploymentTpl,
+	)
 }

--- a/ec/acc/deployment_basic_test.go
+++ b/ec/acc/deployment_basic_test.go
@@ -15,6 +15,8 @@
 // specific language governing permissions and limitations
 // under the License.
 
+// +build acceptance
+
 package acc
 
 import (
@@ -34,11 +36,15 @@ func TestAccDeployment_basic(t *testing.T) {
 	trafficFilterUpdateCfg := "testdata/deployment_basic_with_traffic_filter_update.tf"
 	topologyConfig := "testdata/deployment_basic_topology_config.tf"
 	topConfig := "testdata/deployment_basic_top_config.tf"
-	cfg := testAccDeploymentResourceBasic(t, startCfg, randomName, region, deploymentVersion)
-	cfgWithTrafficFilter := testAccDeploymentResourceBasicWithTF(t, trafficFilterCfg, randomName, region, deploymentVersion)
-	cfgWithTrafficFilterUpdate := testAccDeploymentResourceBasicWithTF(t, trafficFilterUpdateCfg, randomName, region, deploymentVersion)
-	topologyConfigCfg := testAccDeploymentResourceBasic(t, topologyConfig, randomName, region, deploymentVersion)
-	topConfigCfg := testAccDeploymentResourceBasic(t, topConfig, randomName, region, deploymentVersion)
+	cfg := fixtureAccDeploymentResourceBasic(t, startCfg, randomName, getRegion(), defaultTemplate)
+	cfgWithTrafficFilter := fixtureAccDeploymentResourceBasicWithTF(t, trafficFilterCfg, randomName, getRegion(), defaultTemplate)
+	cfgWithTrafficFilterUpdate := fixtureAccDeploymentResourceBasicWithTF(t, trafficFilterUpdateCfg, randomName, getRegion(), defaultTemplate)
+	topologyConfigCfg := fixtureAccDeploymentResourceBasicDefaults(t, topologyConfig, randomName, getRegion(), defaultTemplate)
+	topConfigCfg := fixtureAccDeploymentResourceBasic(t, topConfig, randomName, getRegion(), defaultTemplate)
+	deploymentVersion, err := latestStackVersion()
+	if err != nil {
+		t.Fatal(err)
+	}
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:          func() { testAccPreCheck(t) },
@@ -47,7 +53,7 @@ func TestAccDeployment_basic(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: cfg,
-				Check: checkBasicDeploymentResource(resName, randomName,
+				Check: checkBasicDeploymentResource(resName, randomName, deploymentVersion,
 					resource.TestCheckResourceAttr(resName, "apm.0.config.#", "0"),
 					resource.TestCheckResourceAttr(resName, "elasticsearch.0.config.#", "0"),
 					resource.TestCheckResourceAttr(resName, "elasticsearch.0.topology.0.config.#", "0"),
@@ -61,7 +67,7 @@ func TestAccDeployment_basic(t *testing.T) {
 			{Config: cfg, PlanOnly: true},
 			{
 				Config: cfgWithTrafficFilter,
-				Check: checkBasicDeploymentResource(resName, randomName,
+				Check: checkBasicDeploymentResource(resName, randomName, deploymentVersion,
 					resource.TestCheckResourceAttr(resName, "traffic_filter.#", "1"),
 				),
 			},
@@ -69,7 +75,7 @@ func TestAccDeployment_basic(t *testing.T) {
 			{Config: cfgWithTrafficFilter, PlanOnly: true},
 			{
 				Config: cfgWithTrafficFilterUpdate,
-				Check: checkBasicDeploymentResource(resName, randomName,
+				Check: checkBasicDeploymentResource(resName, randomName, deploymentVersion,
 					resource.TestCheckResourceAttr(resName, "traffic_filter.#", "1"),
 				),
 			},
@@ -78,7 +84,7 @@ func TestAccDeployment_basic(t *testing.T) {
 			// Remove traffic filter.
 			{
 				Config: cfg,
-				Check: checkBasicDeploymentResource(resName, randomName,
+				Check: checkBasicDeploymentResource(resName, randomName, deploymentVersion,
 					resource.TestCheckResourceAttr(resName, "elasticsearch.0.config.#", "0"),
 					resource.TestCheckResourceAttr(resName, "elasticsearch.0.topology.0.config.#", "0"),
 					resource.TestCheckResourceAttr(resName, "traffic_filter.#", "0"),
@@ -89,7 +95,7 @@ func TestAccDeployment_basic(t *testing.T) {
 			{Config: cfg, PlanOnly: true},
 			{
 				Config: topologyConfigCfg,
-				Check: checkBasicDeploymentResource(resName, randomName,
+				Check: checkBasicDeploymentResource(resName, randomName, deploymentVersion,
 					resource.TestCheckResourceAttr(resName, "apm.0.config.#", "0"),
 					resource.TestCheckResourceAttr(resName, "elasticsearch.0.config.#", "0"),
 					resource.TestCheckResourceAttr(resName, "elasticsearch.0.topology.0.config.0.user_settings_yaml", "action.auto_create_index: true"),
@@ -106,7 +112,7 @@ func TestAccDeployment_basic(t *testing.T) {
 			{Config: topologyConfigCfg, PlanOnly: true},
 			{
 				Config: topConfigCfg,
-				Check: checkBasicDeploymentResource(resName, randomName,
+				Check: checkBasicDeploymentResource(resName, randomName, deploymentVersion,
 					resource.TestCheckResourceAttr(resName, "elasticsearch.0.topology.0.config.#", "0"),
 					resource.TestCheckResourceAttr(resName, "elasticsearch.0.config.0.user_settings_yaml", "action.auto_create_index: true"),
 					resource.TestCheckResourceAttr(resName, "apm.0.config.0.debug_enabled", "true"),
@@ -123,7 +129,7 @@ func TestAccDeployment_basic(t *testing.T) {
 			{Config: topConfigCfg, PlanOnly: true},
 			{
 				Config: cfg,
-				Check: checkBasicDeploymentResource(resName, randomName,
+				Check: checkBasicDeploymentResource(resName, randomName, deploymentVersion,
 					resource.TestCheckResourceAttr(resName, "apm.0.config.#", "1"),
 					resource.TestCheckResourceAttr(resName, "elasticsearch.0.config.#", "0"),
 					resource.TestCheckResourceAttr(resName, "elasticsearch.0.topology.0.config.#", "0"),
@@ -147,34 +153,43 @@ func TestAccDeployment_basic(t *testing.T) {
 	})
 }
 
-func testAccDeploymentResourceBasic(t *testing.T, fileName, name, region, version string) string {
+func fixtureAccDeploymentResourceBasic(t *testing.T, fileName, name, region, depTpl string) string {
+	deploymentTpl := setDefaultTemplate(region, depTpl)
+
+	esIC, kibanaIC, apmIC, essIC, err := setInstanceConfigurations(deploymentTpl)
+	if err != nil {
+		t.Fatal(err)
+	}
+
 	b, err := ioutil.ReadFile(fileName)
 	if err != nil {
 		t.Fatal(err)
 	}
 	return fmt.Sprintf(string(b),
-		name, region, version,
+		region, name, region, deploymentTpl, esIC, kibanaIC, apmIC, essIC,
 	)
 }
 
-func testAccDeploymentResourceBasicWithTF(t *testing.T, fileName, name, region, version string) string {
+func fixtureAccDeploymentResourceBasicWithTF(t *testing.T, fileName, name, region, depTpl string) string {
+	deploymentTpl := setDefaultTemplate(region, depTpl)
+
 	b, err := ioutil.ReadFile(fileName)
 	if err != nil {
 		t.Fatal(err)
 	}
 	return fmt.Sprintf(string(b),
-		name, region, version, name, region,
+		region, name, region, deploymentTpl, name, region,
 	)
 }
 
-func checkBasicDeploymentResource(resName, randomDeploymentName string, checks ...resource.TestCheckFunc) resource.TestCheckFunc {
+func checkBasicDeploymentResource(resName, randomDeploymentName, deploymentVersion string, checks ...resource.TestCheckFunc) resource.TestCheckFunc {
 	return resource.ComposeAggregateTestCheckFunc(append([]resource.TestCheckFunc{
 		testAccCheckDeploymentExists(resName),
 		resource.TestCheckResourceAttr(resName, "name", randomDeploymentName),
-		resource.TestCheckResourceAttr(resName, "region", region),
+		resource.TestCheckResourceAttr(resName, "region", getRegion()),
 		resource.TestCheckResourceAttr(resName, "apm.#", "1"),
 		resource.TestCheckResourceAttr(resName, "apm.0.version", deploymentVersion),
-		resource.TestCheckResourceAttr(resName, "apm.0.region", region),
+		resource.TestCheckResourceAttr(resName, "apm.0.region", getRegion()),
 		resource.TestCheckResourceAttr(resName, "apm.0.topology.0.size", "0.5g"),
 		resource.TestCheckResourceAttr(resName, "apm.0.topology.0.size_resource", "memory"),
 		resource.TestCheckResourceAttrSet(resName, "apm_secret_token"),
@@ -184,21 +199,21 @@ func checkBasicDeploymentResource(resName, randomDeploymentName string, checks .
 		resource.TestCheckResourceAttrSet(resName, "apm.0.https_endpoint"),
 		resource.TestCheckResourceAttr(resName, "elasticsearch.#", "1"),
 		resource.TestCheckResourceAttr(resName, "elasticsearch.0.version", deploymentVersion),
-		resource.TestCheckResourceAttr(resName, "elasticsearch.0.region", region),
+		resource.TestCheckResourceAttr(resName, "elasticsearch.0.region", getRegion()),
 		resource.TestCheckResourceAttr(resName, "elasticsearch.0.topology.0.size", "1g"),
 		resource.TestCheckResourceAttr(resName, "elasticsearch.0.topology.0.size_resource", "memory"),
 		resource.TestCheckResourceAttrSet(resName, "elasticsearch.0.http_endpoint"),
 		resource.TestCheckResourceAttrSet(resName, "elasticsearch.0.https_endpoint"),
 		resource.TestCheckResourceAttr(resName, "kibana.#", "1"),
 		resource.TestCheckResourceAttr(resName, "kibana.0.version", deploymentVersion),
-		resource.TestCheckResourceAttr(resName, "kibana.0.region", region),
+		resource.TestCheckResourceAttr(resName, "kibana.0.region", getRegion()),
 		resource.TestCheckResourceAttr(resName, "kibana.0.topology.0.size", "1g"),
 		resource.TestCheckResourceAttr(resName, "kibana.0.topology.0.size_resource", "memory"),
 		resource.TestCheckResourceAttrSet(resName, "kibana.0.http_endpoint"),
 		resource.TestCheckResourceAttrSet(resName, "kibana.0.https_endpoint"),
 		resource.TestCheckResourceAttr(resName, "enterprise_search.#", "1"),
 		resource.TestCheckResourceAttr(resName, "enterprise_search.0.version", deploymentVersion),
-		resource.TestCheckResourceAttr(resName, "enterprise_search.0.region", region),
+		resource.TestCheckResourceAttr(resName, "enterprise_search.0.region", getRegion()),
 		resource.TestCheckResourceAttr(resName, "enterprise_search.0.topology.0.size", "2g"),
 		resource.TestCheckResourceAttr(resName, "enterprise_search.0.topology.0.size_resource", "memory"),
 		resource.TestCheckResourceAttrSet(resName, "enterprise_search.0.http_endpoint"),

--- a/ec/acc/deployment_checks_test.go
+++ b/ec/acc/deployment_checks_test.go
@@ -15,6 +15,8 @@
 // specific language governing permissions and limitations
 // under the License.
 
+// +build acceptance
+
 package acc
 
 import (

--- a/ec/acc/deployment_config_test.go
+++ b/ec/acc/deployment_config_test.go
@@ -15,9 +15,149 @@
 // specific language governing permissions and limitations
 // under the License.
 
+// +build acceptance
+
 package acc
 
-const (
-	deploymentVersion = "7.9.2"
-	region            = "us-east-1"
+import (
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/elastic/cloud-sdk-go/pkg/api/deploymentapi/deptemplateapi"
+	"github.com/elastic/cloud-sdk-go/pkg/api/stackapi"
+	"github.com/elastic/cloud-sdk-go/pkg/models"
 )
+
+const (
+	defaultTemplate = "io-optimized"
+	hotWarmTemplate = "hot-warm"
+
+	// This deployment template is only used for the
+	// TestAccDatasourceDeployment_basic test.
+	depsDSTemplate = "compute-optimized"
+)
+
+func getRegion() string {
+	region := "us-east-1"
+
+	if r := os.Getenv("EC_REGION"); r != "" {
+		region = r
+	}
+
+	return region
+}
+
+func latestStackVersion() (string, error) {
+	client, err := newAPI()
+	if err != nil {
+		return "", err
+	}
+
+	res, err := stackapi.List(stackapi.ListParams{
+		API:    client,
+		Region: getRegion(),
+	})
+	if err != nil {
+		return "", err
+	}
+
+	return res.Stacks[0].Version, nil
+}
+
+func setDefaultTemplate(region, template string) string {
+	if strings.Contains(region, "azure") {
+		region = "azure"
+	}
+
+	if strings.Contains(region, "gcp") {
+		region = "gcp"
+	}
+
+	switch region {
+	case "azure":
+		return "azure-" + template
+	case "gcp":
+		return "gcp-" + template
+	default:
+		return "aws-" + template + "-v2"
+	}
+}
+
+func getResources(deploymentTemplate string) (*models.DeploymentCreateResources, error) {
+	client, err := newAPI()
+	if err != nil {
+		return nil, err
+	}
+
+	res, err := deptemplateapi.Get(deptemplateapi.GetParams{
+		API:        client,
+		TemplateID: deploymentTemplate,
+		Region:     getRegion(),
+		AsList:     true,
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	return res.DeploymentTemplate.Resources, nil
+}
+
+func setInstanceConfigurations(deploymentTemplate string) (esIC, kibanaIC, apmIC, essIC string, err error) {
+	resources, err := getResources(deploymentTemplate)
+	if err != nil {
+		return "", "", "", "", err
+	}
+
+	esRes := resources.Elasticsearch[0].Plan.ClusterTopology
+
+	for _, t := range esRes {
+		if *t.Size.Value > 0 {
+			esIC = t.InstanceConfigurationID
+		}
+	}
+
+	if esIC == "" {
+		return "", "", "", "",
+			fmt.Errorf(
+				"could not find default instance configuration for Elasticsearch, verify  details for: %v",
+				deploymentTemplate)
+	}
+
+	kibanaIC = resources.Kibana[0].
+		Plan.ClusterTopology[0].InstanceConfigurationID
+
+	apmIC = resources.Apm[0].
+		Plan.ClusterTopology[0].InstanceConfigurationID
+
+	essIC = resources.EnterpriseSearch[0].
+		Plan.ClusterTopology[0].InstanceConfigurationID
+
+	return esIC, kibanaIC, apmIC, essIC, nil
+}
+
+func setInstanceConfigurationsHW(deploymentTemplate string) (esIC, esIC2 string, err error) {
+	resources, err := getResources(deploymentTemplate)
+	if err != nil {
+		return "", "", err
+	}
+
+	esRes := resources.Elasticsearch[0].Plan.ClusterTopology
+
+	esICs := []string{}
+	for _, t := range esRes {
+		if *t.Size.Value > 0 {
+			ic := t.InstanceConfigurationID
+			esICs = append(esICs, ic)
+		}
+	}
+
+	if len(esICs) == 2 {
+		return esICs[0], esICs[1], nil
+	}
+
+	return "", "", fmt.Errorf(
+		"%v, is not a valid Hot/Warm deployment template, (elements: %v)",
+		deploymentTemplate, esICs,
+	)
+}

--- a/ec/acc/deployment_destroy_test.go
+++ b/ec/acc/deployment_destroy_test.go
@@ -15,6 +15,8 @@
 // specific language governing permissions and limitations
 // under the License.
 
+// +build acceptance
+
 package acc
 
 import (

--- a/ec/acc/deployment_hotwarm_test.go
+++ b/ec/acc/deployment_hotwarm_test.go
@@ -15,9 +15,13 @@
 // specific language governing permissions and limitations
 // under the License.
 
+// +build acceptance
+
 package acc
 
 import (
+	"fmt"
+	"io/ioutil"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
@@ -32,8 +36,8 @@ func TestAccDeployment_hotwarm(t *testing.T) {
 	randomName := prefix + acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum)
 	startCfg := "testdata/deployment_hotwarm_1.tf"
 	secondCfg := "testdata/deployment_hotwarm_2.tf"
-	cfg := testAccDeploymentResourceBasic(t, startCfg, randomName, region, deploymentVersion)
-	secondConfigCfg := testAccDeploymentResourceBasic(t, secondCfg, randomName, region, deploymentVersion)
+	cfg := fixtureAccDeploymentResourceBasicDefaults(t, startCfg, randomName, getRegion(), hotWarmTemplate)
+	secondConfigCfg := fixtureAccDeploymentResourceBasicHW(t, secondCfg, randomName, getRegion(), hotWarmTemplate)
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:          func() { testAccPreCheck(t) },
@@ -100,4 +104,21 @@ func TestAccDeployment_hotwarm(t *testing.T) {
 			},
 		},
 	})
+}
+
+func fixtureAccDeploymentResourceBasicHW(t *testing.T, fileName, name, region, depTpl string) string {
+	deploymentTpl := setDefaultTemplate(region, depTpl)
+
+	esIC, esIC2, err := setInstanceConfigurationsHW(deploymentTpl)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	b, err := ioutil.ReadFile(fileName)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return fmt.Sprintf(string(b),
+		region, name, region, deploymentTpl, esIC, esIC2,
+	)
 }

--- a/ec/acc/deployment_sweep_test.go
+++ b/ec/acc/deployment_sweep_test.go
@@ -15,6 +15,8 @@
 // specific language governing permissions and limitations
 // under the License.
 
+// +build acceptance
+
 package acc
 
 import (

--- a/ec/acc/deployment_traffic_filter_association_test.go
+++ b/ec/acc/deployment_traffic_filter_association_test.go
@@ -15,6 +15,8 @@
 // specific language governing permissions and limitations
 // under the License.
 
+// +build acceptance
+
 package acc
 
 import (
@@ -34,8 +36,8 @@ func TestAccDeploymentTrafficFilterAssociation_basic(t *testing.T) {
 	randomNameSecond := acctest.RandomWithPrefix(prefix)
 	startCfg := "testdata/deployment_traffic_filter_association_basic.tf"
 	updateCfg := "testdata/deployment_traffic_filter_association_basic_update.tf"
-	cfg := testAccDeploymentTrafficFilterResourceAssociationBasic(t, startCfg, randomName, region, deploymentVersion)
-	updateConfigCfg := testAccDeploymentTrafficFilterResourceAssociationBasic(t, updateCfg, randomNameSecond, region, deploymentVersion)
+	cfg := fixtureAccDeploymentTrafficFilterResourceAssociationBasic(t, startCfg, randomName, getRegion(), defaultTemplate)
+	updateConfigCfg := fixtureAccDeploymentTrafficFilterResourceAssociationBasic(t, updateCfg, randomNameSecond, getRegion(), defaultTemplate)
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:          func() { testAccPreCheck(t) },
@@ -72,13 +74,15 @@ func TestAccDeploymentTrafficFilterAssociation_basic(t *testing.T) {
 	})
 }
 
-func testAccDeploymentTrafficFilterResourceAssociationBasic(t *testing.T, fileName, name, region, version string) string {
+func fixtureAccDeploymentTrafficFilterResourceAssociationBasic(t *testing.T, fileName, name, region, depTpl string) string {
+	deploymentTpl := setDefaultTemplate(region, depTpl)
+
 	b, err := ioutil.ReadFile(fileName)
 	if err != nil {
 		t.Fatal(err)
 	}
 	return fmt.Sprintf(string(b),
-		name, region, version, name, region,
+		region, name, region, deploymentTpl, name, region,
 	)
 }
 
@@ -88,6 +92,6 @@ func checkBasicDeploymentTrafficFilterAssociationResource(resName, assocName, ra
 		resource.TestCheckResourceAttrSet(assocName, "deployment_id"),
 		resource.TestCheckResourceAttrSet(assocName, "traffic_filter_id"),
 		resource.TestCheckResourceAttr(resName, "name", randomDeploymentName),
-		resource.TestCheckResourceAttr(resName, "region", region)}, checks...)...,
+		resource.TestCheckResourceAttr(resName, "region", getRegion())}, checks...)...,
 	)
 }

--- a/ec/acc/deployment_traffic_filter_checks_test.go
+++ b/ec/acc/deployment_traffic_filter_checks_test.go
@@ -15,6 +15,8 @@
 // specific language governing permissions and limitations
 // under the License.
 
+// +build acceptance
+
 package acc
 
 import (

--- a/ec/acc/deployment_traffic_filter_destroy_test.go
+++ b/ec/acc/deployment_traffic_filter_destroy_test.go
@@ -15,6 +15,8 @@
 // specific language governing permissions and limitations
 // under the License.
 
+// +build acceptance
+
 package acc
 
 import (

--- a/ec/acc/deployment_traffic_filter_sweep_test.go
+++ b/ec/acc/deployment_traffic_filter_sweep_test.go
@@ -15,6 +15,8 @@
 // specific language governing permissions and limitations
 // under the License.
 
+// +build acceptance
+
 package acc
 
 import (

--- a/ec/acc/deployment_traffic_filter_test.go
+++ b/ec/acc/deployment_traffic_filter_test.go
@@ -15,6 +15,8 @@
 // specific language governing permissions and limitations
 // under the License.
 
+// +build acceptance
+
 package acc
 
 import (
@@ -31,8 +33,8 @@ func TestAccDeploymentTrafficFilter_basic(t *testing.T) {
 	randomName := prefix + acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum)
 	startCfg := "testdata/deployment_traffic_filter_basic.tf"
 	updateCfg := "testdata/deployment_traffic_filter_basic_update.tf"
-	cfg := testAccDeploymentTrafficFilterResourceBasic(t, startCfg, randomName, region)
-	updateConfigCfg := testAccDeploymentTrafficFilterResourceBasic(t, updateCfg, randomName, region)
+	cfg := fixtureAccDeploymentTrafficFilterResourceBasic(t, startCfg, randomName, getRegion())
+	updateConfigCfg := fixtureAccDeploymentTrafficFilterResourceBasic(t, updateCfg, randomName, getRegion())
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:          func() { testAccPreCheck(t) },
@@ -72,7 +74,7 @@ func TestAccDeploymentTrafficFilter_basic(t *testing.T) {
 	})
 }
 
-func testAccDeploymentTrafficFilterResourceBasic(t *testing.T, fileName, name, region string) string {
+func fixtureAccDeploymentTrafficFilterResourceBasic(t *testing.T, fileName, name, region string) string {
 	b, err := ioutil.ReadFile(fileName)
 	if err != nil {
 		t.Fatal(err)
@@ -86,6 +88,6 @@ func checkBasicDeploymentTrafficFilterResource(resName, randomDeploymentName str
 	return resource.ComposeAggregateTestCheckFunc(append([]resource.TestCheckFunc{
 		testAccCheckDeploymentTrafficFilterExists(resName),
 		resource.TestCheckResourceAttr(resName, "name", randomDeploymentName),
-		resource.TestCheckResourceAttr(resName, "region", region)}, checks...)...,
+		resource.TestCheckResourceAttr(resName, "region", getRegion())}, checks...)...,
 	)
 }

--- a/ec/acc/sweep_test.go
+++ b/ec/acc/sweep_test.go
@@ -15,6 +15,8 @@
 // specific language governing permissions and limitations
 // under the License.
 
+// +build acceptance
+
 package acc
 
 import (

--- a/ec/acc/testdata/datasource_deployment_basic.tf
+++ b/ec/acc/testdata/datasource_deployment_basic.tf
@@ -1,38 +1,25 @@
-resource "ec_deployment" "basic_datasource" {
-  name    = "%s"
-  region  = "%s"
-  version = "%s"
+data "ec_stack" "latest" {
+  version_regex = "latest"
+  region        = "%s"
+}
 
-  # TODO: Make this template ID dependent on the region.
-  # This test should be the only one which uses the 
-  # "aws-compute-optimized-v2" template in order to have
-  # consistent query results.
-  deployment_template_id = "aws-compute-optimized-v2"
+resource "ec_deployment" "basic_datasource" {
+  name                   = "%s"
+  region                 = "%s"
+  version                = data.ec_stack.latest.version
+  deployment_template_id = "%s"
 
   elasticsearch {
     topology {
-      instance_configuration_id = "aws.data.highcpu.m5d"
-      size                      = "1g"
+      size = "1g"
     }
   }
 
-  kibana {
-    topology {
-      instance_configuration_id = "aws.kibana.r5d"
-    }
-  }
+  kibana {}
 
-  apm {
-    topology {
-      instance_configuration_id = "aws.apm.r5d"
-    }
-  }
+  apm {}
 
-  enterprise_search {
-    topology {
-      instance_configuration_id = "aws.enterprisesearch.m5d"
-    }
-  }
+  enterprise_search {}
 
   traffic_filter = [
     ec_deployment_traffic_filter.default.id,
@@ -54,22 +41,22 @@ data "ec_deployment" "success" {
 }
 
 data "ec_deployments" "query" {
-  name_prefix            = substr(ec_deployment.basic_datasource.name, 0, 22) 
-  deployment_template_id = "aws-compute-optimized-v2"
+  name_prefix            = substr(ec_deployment.basic_datasource.name, 0, 22)
+  deployment_template_id = "%s"
 
   elasticsearch {
-    version = "%s"
+    version = data.ec_stack.latest.version
   }
 
   kibana {
-    version = "%s"
+    version = data.ec_stack.latest.version
   }
 
   apm {
-    version = "%s"
+    version = data.ec_stack.latest.version
   }
 
   enterprise_search {
-    version = "%s"
+    version = data.ec_stack.latest.version
   }
 }

--- a/ec/acc/testdata/deployment_basic.tf
+++ b/ec/acc/testdata/deployment_basic.tf
@@ -1,33 +1,36 @@
-resource "ec_deployment" "basic" {
-  name    = "%s"
-  region  = "%s"
-  version = "%s"
+data "ec_stack" "latest" {
+  version_regex = "latest"
+  region        = "%s"
+}
 
-  # TODO: Make this template ID dependent on the region.
-  deployment_template_id = "aws-io-optimized-v2"
+resource "ec_deployment" "basic" {
+  name                   = "%s"
+  region                 = "%s"
+  version                = data.ec_stack.latest.version
+  deployment_template_id = "%s"
 
   elasticsearch {
     topology {
-      instance_configuration_id = "aws.data.highio.i3"
+      instance_configuration_id = "%s"
       size                      = "1g"
     }
   }
 
   kibana {
     topology {
-      instance_configuration_id = "aws.kibana.r5d"
+      instance_configuration_id = "%s"
     }
   }
 
   apm {
     topology {
-      instance_configuration_id = "aws.apm.r5d"
+      instance_configuration_id = "%s"
     }
   }
 
   enterprise_search {
     topology {
-      instance_configuration_id = "aws.enterprisesearch.m5d"
+      instance_configuration_id = "%s"
     }
   }
 }

--- a/ec/acc/testdata/deployment_basic_defaults_1.tf
+++ b/ec/acc/testdata/deployment_basic_defaults_1.tf
@@ -1,10 +1,13 @@
-resource "ec_deployment" "defaults" {
-  name    = "%s"
-  region  = "%s"
-  version = "%s"
+data "ec_stack" "latest" {
+  version_regex = "latest"
+  region        = "%s"
+}
 
-  # TODO: Make this template ID dependent on the region.
-  deployment_template_id = "aws-io-optimized-v2"
+resource "ec_deployment" "defaults" {
+  name                   = "%s"
+  region                 = "%s"
+  version                = data.ec_stack.latest.version
+  deployment_template_id = "%s"
 
   elasticsearch {}
 

--- a/ec/acc/testdata/deployment_basic_defaults_2.tf
+++ b/ec/acc/testdata/deployment_basic_defaults_2.tf
@@ -1,10 +1,13 @@
-resource "ec_deployment" "defaults" {
-  name    = "%s"
-  region  = "%s"
-  version = "%s"
+data "ec_stack" "latest" {
+  version_regex = "latest"
+  region        = "%s"
+}
 
-  # TODO: Make this template ID dependent on the region.
-  deployment_template_id = "aws-io-optimized-v2"
+resource "ec_deployment" "defaults" {
+  name                   = "%s"
+  region                 = "%s"
+  version                = data.ec_stack.latest.version
+  deployment_template_id = "%s"
 
   elasticsearch {}
 

--- a/ec/acc/testdata/deployment_basic_defaults_3.tf
+++ b/ec/acc/testdata/deployment_basic_defaults_3.tf
@@ -1,10 +1,13 @@
-resource "ec_deployment" "defaults" {
-  name    = "%s"
-  region  = "%s"
-  version = "%s"
+data "ec_stack" "latest" {
+  version_regex = "latest"
+  region        = "%s"
+}
 
-  # TODO: Make this template ID dependent on the region.
-  deployment_template_id = "aws-io-optimized-v2"
+resource "ec_deployment" "defaults" {
+  name                   = "%s"
+  region                 = "%s"
+  version                = data.ec_stack.latest.version
+  deployment_template_id = "%s"
 
   elasticsearch {
     topology {

--- a/ec/acc/testdata/deployment_basic_defaults_4.tf
+++ b/ec/acc/testdata/deployment_basic_defaults_4.tf
@@ -1,10 +1,13 @@
-resource "ec_deployment" "defaults" {
-  name    = "%s"
-  region  = "%s"
-  version = "%s"
+data "ec_stack" "latest" {
+  version_regex = "latest"
+  region        = "%s"
+}
 
-  # TODO: Make this template ID dependent on the region.
-  deployment_template_id = "aws-hot-warm-v2"
+resource "ec_deployment" "defaults" {
+  name                   = "%s"
+  region                 = "%s"
+  version                = data.ec_stack.latest.version
+  deployment_template_id = "%s"
 
   elasticsearch {}
 }

--- a/ec/acc/testdata/deployment_basic_top_config.tf
+++ b/ec/acc/testdata/deployment_basic_top_config.tf
@@ -1,17 +1,20 @@
-resource "ec_deployment" "basic" {
-  name    = "%s"
-  region  = "%s"
-  version = "%s"
+data "ec_stack" "latest" {
+  version_regex = "latest"
+  region        = "%s"
+}
 
-  # TODO: Make this template ID dependent on the region.
-  deployment_template_id = "aws-io-optimized-v2"
+resource "ec_deployment" "basic" {
+  name                   = "%s"
+  region                 = "%s"
+  version                = data.ec_stack.latest.version
+  deployment_template_id = "%s"
 
   elasticsearch {
     config {
       user_settings_yaml = "action.auto_create_index: true"
     }
     topology {
-      instance_configuration_id = "aws.data.highio.i3"
+      instance_configuration_id = "%s"
       size                      = "1g"
     }
   }
@@ -21,7 +24,7 @@ resource "ec_deployment" "basic" {
       user_settings_yaml = "csp.warnLegacyBrowsers: true"
     }
     topology {
-      instance_configuration_id = "aws.kibana.r5d"
+      instance_configuration_id = "%s"
     }
   }
 
@@ -30,7 +33,7 @@ resource "ec_deployment" "basic" {
       debug_enabled = true
     }
     topology {
-      instance_configuration_id = "aws.apm.r5d"
+      instance_configuration_id = "%s"
     }
   }
 
@@ -39,7 +42,7 @@ resource "ec_deployment" "basic" {
       user_settings_yaml = "ent_search.login_assistance_message: somemessage"
     }
     topology {
-      instance_configuration_id = "aws.enterprisesearch.m5d"
+      instance_configuration_id = "%s"
     }
   }
 }

--- a/ec/acc/testdata/deployment_basic_topology_config.tf
+++ b/ec/acc/testdata/deployment_basic_topology_config.tf
@@ -1,18 +1,20 @@
-resource "ec_deployment" "basic" {
-  name    = "%s"
-  region  = "%s"
-  version = "%s"
+data "ec_stack" "latest" {
+  version_regex = "latest"
+  region        = "%s"
+}
 
-  # TODO: Make this template ID dependent on the region.
-  deployment_template_id = "aws-io-optimized-v2"
+resource "ec_deployment" "basic" {
+  name                   = "%s"
+  region                 = "%s"
+  version                = data.ec_stack.latest.version
+  deployment_template_id = "%s"
 
   elasticsearch {
     topology {
       config {
         user_settings_yaml = "action.auto_create_index: true"
       }
-      instance_configuration_id = "aws.data.highio.i3"
-      size                      = "1g"
+      size = "1g"
     }
   }
 
@@ -21,7 +23,6 @@ resource "ec_deployment" "basic" {
       config {
         user_settings_yaml = "csp.warnLegacyBrowsers: true"
       }
-      instance_configuration_id = "aws.kibana.r5d"
     }
   }
 
@@ -30,7 +31,6 @@ resource "ec_deployment" "basic" {
       config {
         debug_enabled = true
       }
-      instance_configuration_id = "aws.apm.r5d"
     }
   }
 
@@ -39,7 +39,6 @@ resource "ec_deployment" "basic" {
       config {
         user_settings_yaml = "ent_search.login_assistance_message: somemessage"
       }
-      instance_configuration_id = "aws.enterprisesearch.m5d"
     }
   }
 }

--- a/ec/acc/testdata/deployment_basic_with_traffic_filter.tf
+++ b/ec/acc/testdata/deployment_basic_with_traffic_filter.tf
@@ -1,35 +1,25 @@
-resource "ec_deployment" "basic" {
-  name    = "%s"
-  region  = "%s"
-  version = "%s"
+data "ec_stack" "latest" {
+  version_regex = "latest"
+  region        = "%s"
+}
 
-  # TODO: Make this template ID dependent on the region.
-  deployment_template_id = "aws-io-optimized-v2"
+resource "ec_deployment" "basic" {
+  name                   = "%s"
+  region                 = "%s"
+  version                = data.ec_stack.latest.version
+  deployment_template_id = "%s"
 
   elasticsearch {
     topology {
-      instance_configuration_id = "aws.data.highio.i3"
-      size                      = "1g"
+      size = "1g"
     }
   }
 
-  kibana {
-    topology {
-      instance_configuration_id = "aws.kibana.r5d"
-    }
-  }
+  kibana {}
 
-  apm {
-    topology {
-      instance_configuration_id = "aws.apm.r5d"
-    }
-  }
+  apm {}
 
-  enterprise_search {
-    topology {
-      instance_configuration_id = "aws.enterprisesearch.m5d"
-    }
-  }
+  enterprise_search {}
 
   traffic_filter = [
     ec_deployment_traffic_filter.default.id,

--- a/ec/acc/testdata/deployment_basic_with_traffic_filter_update.tf
+++ b/ec/acc/testdata/deployment_basic_with_traffic_filter_update.tf
@@ -1,35 +1,25 @@
-resource "ec_deployment" "basic" {
-  name    = "%s"
-  region  = "%s"
-  version = "%s"
+data "ec_stack" "latest" {
+  version_regex = "latest"
+  region        = "%s"
+}
 
-  # TODO: Make this template ID dependent on the region.
-  deployment_template_id = "aws-io-optimized-v2"
+resource "ec_deployment" "basic" {
+  name                   = "%s"
+  region                 = "%s"
+  version                = data.ec_stack.latest.version
+  deployment_template_id = "%s"
 
   elasticsearch {
     topology {
-      instance_configuration_id = "aws.data.highio.i3"
-      size                      = "1g"
+      size = "1g"
     }
   }
 
-  kibana {
-    topology {
-      instance_configuration_id = "aws.kibana.r5d"
-    }
-  }
+  kibana {}
 
-  apm {
-    topology {
-      instance_configuration_id = "aws.apm.r5d"
-    }
-  }
+  apm {}
 
-  enterprise_search {
-    topology {
-      instance_configuration_id = "aws.enterprisesearch.m5d"
-    }
-  }
+  enterprise_search {}
 
   traffic_filter = [
     ec_deployment_traffic_filter.second.id,

--- a/ec/acc/testdata/deployment_hotwarm_1.tf
+++ b/ec/acc/testdata/deployment_hotwarm_1.tf
@@ -1,10 +1,13 @@
-resource "ec_deployment" "hotwarm" {
-  name    = "%s"
-  region  = "%s"
-  version = "%s"
+data "ec_stack" "latest" {
+  version_regex = "latest"
+  region        = "%s"
+}
 
-  # TODO: Make this template ID dependent on the region.
-  deployment_template_id = "aws-hot-warm-v2"
+resource "ec_deployment" "hotwarm" {
+  name                   = "%s"
+  region                 = "%s"
+  version                = data.ec_stack.latest.version
+  deployment_template_id = "%s"
 
   elasticsearch {}
 }

--- a/ec/acc/testdata/deployment_hotwarm_2.tf
+++ b/ec/acc/testdata/deployment_hotwarm_2.tf
@@ -1,19 +1,22 @@
-resource "ec_deployment" "hotwarm" {
-  name    = "%s"
-  region  = "%s"
-  version = "%s"
+data "ec_stack" "latest" {
+  version_regex = "latest"
+  region        = "%s"
+}
 
-  # TODO: Make this template ID dependent on the region.
-  deployment_template_id = "aws-hot-warm-v2"
+resource "ec_deployment" "hotwarm" {
+  name                   = "%s"
+  region                 = "%s"
+  version                = data.ec_stack.latest.version
+  deployment_template_id = "%s"
 
   elasticsearch {
     topology {
-      instance_configuration_id = "aws.data.highio.i3"
+      instance_configuration_id = "%s"
       zone_count                = 1
       size                      = "1g"
     }
     topology {
-      instance_configuration_id = "aws.data.highstorage.d2"
+      instance_configuration_id = "%s"
       zone_count                = 1
       size                      = "2g"
     }

--- a/ec/acc/testdata/deployment_traffic_filter_association_basic.tf
+++ b/ec/acc/testdata/deployment_traffic_filter_association_basic.tf
@@ -1,23 +1,21 @@
-resource "ec_deployment" "tf_assoc" {
-  name    = "%s"
-  region  = "%s"
-  version = "%s"
+data "ec_stack" "latest" {
+  version_regex = "latest"
+  region        = "%s"
+}
 
-  # TODO: Make this template ID dependent on the region.
-  deployment_template_id = "aws-io-optimized-v2"
+resource "ec_deployment" "tf_assoc" {
+  name                   = "%s"
+  region                 = "%s"
+  version                = data.ec_stack.latest.version
+  deployment_template_id = "%s"
 
   elasticsearch {
     topology {
-      instance_configuration_id = "aws.data.highio.i3"
-      size                      = "1g"
+      size = "1g"
     }
   }
 
-  kibana {
-    topology {
-      instance_configuration_id = "aws.kibana.r5d"
-    }
-  }
+  kibana {}
 }
 
 resource "ec_deployment_traffic_filter" "tf_assoc" {

--- a/ec/acc/testdata/deployment_traffic_filter_association_basic_update.tf
+++ b/ec/acc/testdata/deployment_traffic_filter_association_basic_update.tf
@@ -1,23 +1,21 @@
-resource "ec_deployment" "tf_assoc" {
-  name    = "%s"
-  region  = "%s"
-  version = "%s"
+data "ec_stack" "latest" {
+  version_regex = "latest"
+  region        = "%s"
+}
 
-  # TODO: Make this template ID dependent on the region.
-  deployment_template_id = "aws-io-optimized-v2"
+resource "ec_deployment" "tf_assoc" {
+  name                   = "%s"
+  region                 = "%s"
+  version                = data.ec_stack.latest.version
+  deployment_template_id = "%s"
 
   elasticsearch {
     topology {
-      instance_configuration_id = "aws.data.highio.i3"
-      size                      = "1g"
+      size = "1g"
     }
   }
 
-  kibana {
-    topology {
-      instance_configuration_id = "aws.kibana.r5d"
-    }
-  }
+  kibana {}
 }
 
 resource "ec_deployment_traffic_filter" "tf_assoc_second" {


### PR DESCRIPTION
All region, deployment_template_id and instance_configuration_id fields
in the acceptance tests are now dynamic. Region fields are set through a
new environment variable EC_REGION, or set to a default if this variable
is not set.

Only ESS regions are supported. ECE environments are not supported as
the deployment template names and configurations will vary depending
on the ECE installation.

Additionally, the files within the testdata/ directory have been modified
to use default values rather specifying topology when it was not necessary
to test this way. This reduced complexity in our test templates.

<!--- Provide a general summary of your changes in the title above. -->

## Description
<!--- Describe your changes in detail. -->

## Related Issues
<!--- This project only accepts pull requests related to open issues. -->
<!--- If suggesting a new feature or change, please discuss it in an -->
<!--- issue first.  If fixing a bug, there should be an issue describing -->
<!--- it with steps to reproduce.  Please link to the any related issues -->
<!--- here: -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes.  Include -->
<!--- details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of Changes
<!--- What types of changes does your code introduce? Put an `x` in -->
<!--- all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (improves code quality but has no user-facing effect)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation

## Readiness Checklist
<!--- Go over all the following points, and put an `x` in all the boxes -->
<!--- that apply.  If you're unsure about any of these, don't hesitate -->
<!--- to ask. We're here to help! -->
- [ ] My code follows the code style of this project
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [ ] All new and existing tests passed
